### PR TITLE
fix(zig): fix buildexe name escape

### DIFF
--- a/snippets/zig.json
+++ b/snippets/zig.json
@@ -17,7 +17,7 @@
 		"prefix": "bExe",
 		"body": [
 			"const exe = b.addExecutable(.{",
-				".name = \"${1}",\",
+				".name = \"${1}\",",
 				".root_source_file = b.path(\"${2: path}\"),",
 				".target = target,",
 				".optimize = optimize,",


### PR DESCRIPTION
Fixes an issue from https://github.com/rafamadriz/friendly-snippets/pull/491#issuecomment-2509807357.